### PR TITLE
Fix recipe pipeline flow and prompt parsing

### DIFF
--- a/src/features/shot-creator/components/creator-prompt-settings/PromptActions.tsx
+++ b/src/features/shot-creator/components/creator-prompt-settings/PromptActions.tsx
@@ -308,8 +308,6 @@ const PromptActions = ({ textareaRef }: { textareaRef: React.RefObject<HTMLTextA
     }, [setActiveRecipe])
 
     // Handle applying a recipe's generated prompts
-    // For multi-stage recipes, we use the first stage prompt for now
-    // Full pipe execution will be handled in the image generation service
     const handleApplyRecipePrompt = useCallback((prompts: string[], recipeReferenceImages: string[]) => {
         // Get the active recipe info before closing
         const recipe = getActiveRecipe()
@@ -328,8 +326,12 @@ const PromptActions = ({ textareaRef }: { textareaRef: React.RefObject<HTMLTextA
             }
         }
 
-        // Use first stage prompt for the main prompt field
-        if (prompts.length > 0) {
+        // If the recipe has multiple stages, chain them using pipe syntax so the generator
+        // runs sequentially and feeds each output into the next stage.
+        // Single-stage recipes just use the single prompt.
+        if (prompts.length > 1) {
+            setShotCreatorPrompt(prompts.join(' | '))
+        } else if (prompts.length === 1) {
             setShotCreatorPrompt(prompts[0])
         }
 

--- a/src/features/shot-creator/helpers/prompt-syntax-feedback.ts
+++ b/src/features/shot-creator/helpers/prompt-syntax-feedback.ts
@@ -405,17 +405,12 @@ function parseBracketsAndPipes(
         }
     }
 
-    // Generate all combinations (flatten the cross-product)
-    // Note: We don't actually use this cartesian product - see flatPrompts below
-    const _allPrompts = cartesianProductStrings(expandedSegments).map(combo => combo.join(' | '))
-
-    // Actually, we want each combination to be a separate prompt, not joined by |
-    // Let me reconsider - each "row" of the cartesian product is one complete prompt set
-    // Actually for generation, we want ALL the individual prompts
-    const flatPrompts: string[] = []
-    for (const segment of expandedSegments) {
-        flatPrompts.push(...segment)
-    }
+    // Generate the full cartesian product so we correctly represent every variation
+    // across all pipe segments.
+    const allCombinations = cartesianProductStrings(expandedSegments)
+    const flatPrompts: string[] = allCombinations.map(combo => combo.join(' | '))
+    const totalCount = flatPrompts.length
+    const creditCostCalculated = totalCount * config.creditsPerImage
 
     return {
         isValid: true,
@@ -426,13 +421,13 @@ function parseBracketsAndPipes(
         originalPrompt: context.originalPrompt,
         wildCardNames: context.hasWildCards ? context.wildCardNames : undefined,
         previewCount: Math.min(flatPrompts.length, config.maxPreview),
-        totalCount: flatPrompts.length,
+        totalCount,
         warnings: [
             ...context.wildCardWarnings,
-            `📸 Generating ${flatPrompts.length} images (${creditCost} credits)`
+            `📸 Generating ${flatPrompts.length} images (${creditCostCalculated} credits)`
         ],
         isCrossCombination: true,
-        creditCost,
+        creditCost: creditCostCalculated,
         imageBreakdown: `${pipeSegments.length} pipe segments with brackets = ${flatPrompts.length} images`
     }
 }

--- a/src/features/shot-creator/hooks/useImageGeneration.ts
+++ b/src/features/shot-creator/hooks/useImageGeneration.ts
@@ -442,9 +442,24 @@ export function useImageGeneration() {
                     disableBracketSyntax: settings.disableBracketSyntax,
                     disableWildcardSyntax: settings.disableWildcardSyntax
                 }, wildcards)
+
+                // If parsing failed (e.g., missing wildcards), surface the warning and abort
+                if (!promptResult.isValid) {
+                    const warning = promptResult.warnings?.[0] || 'Prompt syntax is invalid'
+                    setShotCreatorProcessing(false)
+                    setProgress({ status: 'failed', error: warning })
+                    toast({
+                        title: 'Invalid Prompt',
+                        description: warning,
+                        variant: 'destructive',
+                    })
+                    return
+                }
+
                 variations = promptResult.expandedPrompts
                 totalVariations = promptResult.totalCount
-                isPipeChaining = promptResult.hasPipes
+                // Only chain when we truly have a pipe-based sequential flow (not cross-product combos)
+                isPipeChaining = promptResult.hasPipes && !promptResult.isCrossCombination
 
                 // Log wildcard usage
                 if (promptResult.hasWildCards) {


### PR DESCRIPTION
## Summary
- chain multi-stage recipes by piping all stage prompts so each stage feeds the next during generation
- correct bracket+pipe cross-product expansion to reflect all combinations and credit counts
- fail fast on invalid prompt parsing (e.g., missing wildcards) instead of proceeding with empty variations

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694819c8c9c88323a0328a5e2f27e0c3)