### PR TITLE
fix: bracket text turns black in Shot Creator prompt editor (closes #13)

### DIFF
--- a/src/features/shot-creator/helpers/prompt-syntax-tokenizer.ts
+++ b/src/features/shot-creator/helpers/prompt-syntax-tokenizer.ts
@@ -171,8 +171,8 @@ function tokenizeBracketContent(content: string, tokens: SyntaxToken[]) {
         if (index > 0) {
             tokens.push({ type: 'bracketDelimiter', content: ',' })
         }
-        if (part) {
-            tokens.push({ type: 'bracket', content: part })
-        }
+        // Always push a token even for empty parts so backdrop char count
+        // stays in sync with the textarea, preventing transparent-text bleed-through
+        tokens.push({ type: 'bracket', content: part })
     })
 }

--- a/src/features/shot-creator/services/recipe.service.ts
+++ b/src/features/shot-creator/services/recipe.service.ts
@@ -6,7 +6,7 @@
 
 import { getClient, getAPIClient } from '@/lib/db/client'
 import type { Recipe, RecipeStage, RecipeReferenceImage } from '../types/recipe.types'
-import { parseStageTemplate, SAMPLE_RECIPES } from '../types/recipe.types'
+import { parseStageTemplate } from '../types/recipe.types'
 import { logger } from '@/lib/logger'
 
 // Helper to get an untyped client for recipe tables (not in main DB types yet)


### PR DESCRIPTION
## Summary

- **Root cause:** `tokenizeBracketContent` in `prompt-syntax-tokenizer.ts` skipped empty comma-separated parts with an `if (part)` guard. The `HighlightedPromptEditor` renders a transparent textarea on top of a colored backdrop div. When any token is missing from the backdrop, the backdrop has fewer characters than the textarea, causing transparent text to bleed through to whatever is behind the component — typically appearing **black** on dark backgrounds.
- **Fix:** Always emit a `bracket` token even for empty parts, keeping backdrop and textarea character counts in sync at all times.
- **Bonus fix:** Removes the unused `SAMPLE_RECIPES` import in `recipe.service.ts` that was causing a pre-existing ESLint error blocking clean builds.

## Relevant files
- `src/features/shot-creator/helpers/prompt-syntax-tokenizer.ts` — the one-line guard removal
- `src/features/shot-creator/services/recipe.service.ts` — pre-existing unused import removed

## Test plan
- [ ] Open Shot Creator → type `[option1, option2]` in the prompt field → text inside brackets should be blue, text outside should be light/white (not black)
- [ ] Type `[a,,b]` (consecutive commas) → no black text bleed-through
- [ ] Type `[,]` (empty options) → no black text bleed-through
- [ ] Type a prompt with NO brackets → no syntax highlighting (textarea color unchanged)

## Linked Issue

Closes #13

https://claude.ai/code/session_01BaQsjuHNipMok6TBaCpZT5