### PR TITLE
fix: add 20-minute hard timeout for stuck image generations (closes #12)

### DIFF
--- a/src/features/shot-creator/hooks/useImageGeneration.ts
+++ b/src/features/shot-creator/hooks/useImageGeneration.ts
@@ -246,6 +246,7 @@ export function useImageGeneration() {
 
         let subscription: { unsubscribe: () => void } | null = null
         let timeoutId: NodeJS.Timeout | null = null
+        let hardTimeoutId: NodeJS.Timeout | null = null
         let pollIntervalId: NodeJS.Timeout | null = null
         let resolved = false // Prevent double-handling from subscription + poll racing
 
@@ -254,6 +255,7 @@ export function useImageGeneration() {
             resolved = true
 
             if (timeoutId) clearTimeout(timeoutId)
+            if (hardTimeoutId) clearTimeout(hardTimeoutId)
             if (pollIntervalId) clearInterval(pollIntervalId)
 
             setProgress({ status: 'succeeded' })
@@ -281,6 +283,7 @@ export function useImageGeneration() {
             resolved = true
 
             if (timeoutId) clearTimeout(timeoutId)
+            if (hardTimeoutId) clearTimeout(hardTimeoutId)
             if (pollIntervalId) clearInterval(pollIntervalId)
 
             setProgress({ status: 'failed', error: errorMsg })
@@ -365,7 +368,6 @@ export function useImageGeneration() {
             }
 
             // After initial fast polling (3s), slow down to 5s polling
-            // No hard timeout — keep polling until Replicate returns a terminal status
             if (!resolved) {
                 timeoutId = setTimeout(() => {
                     if (resolved || !pollIntervalId) return
@@ -373,6 +375,17 @@ export function useImageGeneration() {
                     clearInterval(pollIntervalId)
                     pollIntervalId = setInterval(pollCheck, 5000)
                 }, 60000)
+            }
+
+            // Hard timeout: if Replicate never returns a terminal status after 20 minutes,
+            // surface a clear error so the user isn't stuck waiting indefinitely.
+            // Replicate's own infrastructure typically times out within this window.
+            if (!resolved) {
+                hardTimeoutId = setTimeout(() => {
+                    handleError(
+                        'Generation timed out after 20 minutes. Replicate may be experiencing high load — please try again.'
+                    )
+                }, 20 * 60 * 1000)
             }
         }
 
@@ -382,6 +395,7 @@ export function useImageGeneration() {
             resolved = true
             if (subscription) subscription.unsubscribe()
             if (timeoutId) clearTimeout(timeoutId)
+            if (hardTimeoutId) clearTimeout(hardTimeoutId)
             if (pollIntervalId) clearInterval(pollIntervalId)
         }
     }, [activeGalleryId, setShotCreatorProcessing, toast])

--- a/src/features/shot-creator/services/recipe.service.ts
+++ b/src/features/shot-creator/services/recipe.service.ts
@@ -6,7 +6,7 @@
 
 import { getClient, getAPIClient } from '@/lib/db/client'
 import type { Recipe, RecipeStage, RecipeReferenceImage } from '../types/recipe.types'
-import { parseStageTemplate, SAMPLE_RECIPES } from '../types/recipe.types'
+import { parseStageTemplate } from '../types/recipe.types'
 import { logger } from '@/lib/logger'
 
 // Helper to get an untyped client for recipe tables (not in main DB types yet)


### PR DESCRIPTION
## Summary

- **Root cause:** `useImageGeneration.ts` intentionally had no hard timeout on the generation polling loop (`// No hard timeout — keep polling until Replicate returns a terminal status`). When Replicate experiences high load or a webhook silently fails, the ClapperboardSpinner keeps ticking in overtime mode indefinitely — users saw 37+ minute waits with no way to recover short of a manual page reload.
- **Fix:** Add a 20-minute `hardTimeoutId` that calls `handleError()` with a clear, actionable message if Replicate never delivers a terminal status. 20 minutes aligns with Replicate's own infrastructure timeout window. The existing 3s→5s polling speed-down at 60s is unchanged.
- **Note:** The ClapperboardSpinner's timer display itself is **not** a bug — `Math.max(0, …)` clamping is already in place and overtime is rendered correctly. The problem was the missing escape hatch.

## Relevant files
- `src/features/shot-creator/hooks/useImageGeneration.ts:247–389` — the polling/subscription effect

## Test plan
- [ ] Start a generation and verify it completes normally (timeout doesn't fire prematurely)
- [ ] Mock a slow Replicate response (or use a no-op webhook); after 20 minutes the UI should show "Generation timed out after 20 minutes. Replicate may be experiencing high load — please try again." toast and the gallery item should be marked `failed`
- [ ] Verify navigating away before timeout still cleans up all timers (no memory leak)

## Linked Issue

Closes #12

https://claude.ai/code/session_01BaQsjuHNipMok6TBaCpZT5