### PR TITLE
fix: extend character-sheet API timeout to prevent 504 error (closes #16)

### DIFF
--- a/src/app/api/artist-dna/generate-character-sheet/route.ts
+++ b/src/app/api/artist-dna/generate-character-sheet/route.ts
@@ -3,6 +3,9 @@
  * Single model (Nano Banana Pro) — returns { url, prompt }
  */
 
+// Nano Banana 2 takes ~60s to generate + persist. Extend Vercel timeout to prevent 504.
+export const maxDuration = 300
+
 import { NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUser } from '@/lib/auth/api-auth'
 import Replicate from 'replicate'
@@ -161,7 +164,7 @@ export async function POST(request: NextRequest) {
         output_format: 'jpg',
       },
     })
-    const completed = await replicate.wait(prediction, { interval: 1000 })
+    const completed = await replicate.wait(prediction, { interval: 2000 })
 
     if (completed.status === 'succeeded' && completed.output) {
       const replicateUrl = Array.isArray(completed.output)


### PR DESCRIPTION
## Summary

- Adds `export const maxDuration = 300` to `src/app/api/artist-dna/generate-character-sheet/route.ts`
- Reduces `replicate.wait()` polling interval from 1s → 2s to halve unnecessary Replicate API calls during the wait

## Root Cause

`generate-character-sheet/route.ts` uses `replicate.wait()` (synchronous blocking) to wait for Nano Banana 2 image generation. The model's estimated generation time is ~60 seconds (`estimatedSeconds: 60` in config). Without `export const maxDuration`, Vercel's default serverless function timeout fires before generation completes, returning a 504 Gateway Timeout to the client.

This affects both desktop and mobile equally because it is entirely server-side.

## Relevant Files

- `src/app/api/artist-dna/generate-character-sheet/route.ts` — the route using synchronous `replicate.wait()` without a timeout override
- `src/config/index.ts:264` — `estimatedSeconds: 60` confirms generation time exceeds default timeouts

## Linked Issue

Closes #16