### PR TITLE
fix: video download freezes on slow/expired URLs (closes #21)

### DIFF
--- a/src/features/shot-animator/components/AnimatorUnifiedGallery.tsx
+++ b/src/features/shot-animator/components/AnimatorUnifiedGallery.tsx
@@ -98,7 +98,8 @@ export function AnimatorUnifiedGallery({
 
   const handleDownloadBlob = async (video: DerivedVideo) => {
     try {
-      const response = await fetch(video.videoUrl)
+      const response = await fetch(video.videoUrl, { signal: AbortSignal.timeout(30000) })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
       const blob = await response.blob()
       const blobUrl = URL.createObjectURL(blob)
       const link = document.createElement('a')
@@ -112,8 +113,8 @@ export function AnimatorUnifiedGallery({
       link.click()
       document.body.removeChild(link)
       URL.revokeObjectURL(blobUrl)
-    } catch {
-      toast.error('Could not download video.')
+    } catch (error) {
+      toast.error(`Could not download video: ${error instanceof Error ? error.message : 'Please try again.'}`)
     }
   }
 

--- a/src/features/shot-animator/components/CompactVideoCard.tsx
+++ b/src/features/shot-animator/components/CompactVideoCard.tsx
@@ -137,26 +137,20 @@ const CompactVideoCardComponent = ({
 
   const handleDownload = async (videoUrl: string, videoId: string) => {
     try {
-      // Fetch the video as a blob
-      const response = await fetch(videoUrl)
+      const response = await fetch(videoUrl, { signal: AbortSignal.timeout(30000) })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
       const blob = await response.blob()
-
-      // Create a temporary URL for the blob
       const blobUrl = URL.createObjectURL(blob)
-
-      // Create and trigger download
       const link = document.createElement('a')
       link.href = blobUrl
       link.download = `reference_${videoId}.mp4`
       document.body.appendChild(link)
       link.click()
       document.body.removeChild(link)
-
-      // Clean up the blob URL
       URL.revokeObjectURL(blobUrl)
     } catch (error) {
       logger.shotCreator.error('Failed to download video', { error: error instanceof Error ? error.message : String(error) })
-      toast.error('Could not download video. Please try again.')
+      toast.error(`Could not download video: ${error instanceof Error ? error.message : 'Please try again.'}`)
     }
   }
 

--- a/src/features/shot-animator/components/FullscreenVideoModal.tsx
+++ b/src/features/shot-animator/components/FullscreenVideoModal.tsx
@@ -59,7 +59,8 @@ export function FullscreenVideoModal({
 
   const handleDownload = async () => {
     try {
-      const response = await fetch(videoUrl)
+      const response = await fetch(videoUrl, { signal: AbortSignal.timeout(30000) })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
       const blob = await response.blob()
       const blobUrl = URL.createObjectURL(blob)
       const link = document.createElement('a')
@@ -69,8 +70,8 @@ export function FullscreenVideoModal({
       link.click()
       document.body.removeChild(link)
       URL.revokeObjectURL(blobUrl)
-    } catch {
-      toast.error('Could not download video. Please try again.')
+    } catch (error) {
+      toast.error(`Could not download video: ${error instanceof Error ? error.message : 'Please try again.'}`)
     }
   }
 

--- a/src/features/shot-animator/components/VideoPreviewsModal.tsx
+++ b/src/features/shot-animator/components/VideoPreviewsModal.tsx
@@ -93,21 +93,20 @@ const VideoPreviewsModal = ({ isOpen, onClose }: VideoPreviewsModalProps) => {
 
     const handleDownload = async (videoUrl: string, videoId: string) => {
         try {
-            const response = await fetch(videoUrl)
+            const response = await fetch(videoUrl, { signal: AbortSignal.timeout(30000) })
+            if (!response.ok) throw new Error(`HTTP ${response.status}`)
             const blob = await response.blob()
             const blobUrl = URL.createObjectURL(blob)
-
             const link = document.createElement('a')
             link.href = blobUrl
             link.download = `reference_${videoId}.mp4`
             document.body.appendChild(link)
             link.click()
             document.body.removeChild(link)
-
             URL.revokeObjectURL(blobUrl)
         } catch (error) {
             logger.shotCreator.error('Failed to download video', { error: error instanceof Error ? error.message : String(error) })
-            toast.error('Could not download video. Please try again.')
+            toast.error(`Could not download video: ${error instanceof Error ? error.message : 'Please try again.'}`)
         }
     }
 


### PR DESCRIPTION
## Summary

- All four `shot-animator` download handlers were calling `fetch(videoUrl)` with no timeout and no HTTP status check, causing the UI to freeze when the URL was slow to respond, returned a 404/403, or was temporarily unreachable.
- Added `AbortSignal.timeout(30000)` to every download `fetch` call so it fails clearly after 30 s instead of hanging forever.
- Added `if (!response.ok) throw new Error(\`HTTP ${response.status}\`)` so a non-2xx response (expired Storage URL, CORS rejection) throws immediately rather than silently passing an error body into `blob()`.
- Improved error toast messages to surface the actual error string instead of the generic "Could not download video."

## Affected files

- `src/features/shot-animator/components/FullscreenVideoModal.tsx`
- `src/features/shot-animator/components/AnimatorUnifiedGallery.tsx`
- `src/features/shot-animator/components/CompactVideoCard.tsx`
- `src/features/shot-animator/components/VideoPreviewsModal.tsx`

## Linked Issue

Closes #21

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP71QN9s9GFwBETWvZY6GD)_